### PR TITLE
Fix cache storage path

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -44,21 +44,21 @@ cache_secrets_folder <- function() {
   file_path <- list.files(
     pattern = "cached-secrets",
     recursive = TRUE,
-    system.file("extdata", package = "metricminer"),
+    tools::R_user_dir("metricminer", which="cache"),
     full.names = TRUE,
     include.dirs = TRUE,
   )
 
   if (length(file_path) == 0) {
     dir.create(file.path(
-      system.file("extdata", package = "metricminer"),
+      tools::R_user_dir("metricminer", which="cache"),
       "cached-secrets"
     ), recursive = TRUE, showWarnings = FALSE)
   }
   list.files(
     pattern = "cached-secrets",
     recursive = TRUE,
-    system.file("extdata", package = "metricminer"),
+    tools::R_user_dir("metricminer", which="cache"),
     full.names = TRUE,
     include.dirs = TRUE,
   )


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
This addresses #27 by switching where the cached tokens are stored. Thanks for the rec! Can you check if this is right? It appears to work as far as I can tell. 


## How to test
You can test this by running`authorize("github")` and choose to cache then restart the R session -- so the stored PAT is no longer there and in the new session run `get_github_user()`.

