### PR TITLE
pull new file and replace old name

### DIFF
--- a/R/slido.R
+++ b/R/slido.R
@@ -49,6 +49,7 @@ get_slido_files <- function(drive_id, token = NULL, recursive = TRUE, keep_dupli
     "^Polls-overall-",
     "^Replies-",
     "^Polls-per-user-",
+    "^Polls-per-participant-",
     "^Questions-"
   )
 
@@ -63,6 +64,7 @@ get_slido_files <- function(drive_id, token = NULL, recursive = TRUE, keep_dupli
   event_names_regex <- paste0(slido_event_name, collapse = "|")
   slido_type <- stringr::word(slido_file_names, sep = event_names_regex, start = 1)
   slido_type <- gsub("-$", "", slido_type)
+  slido_type <- gsub("Polls-per-user", "Polls-per-participant", slido_type)
 
   # Set up data frame
   slido_files <- file_info %>%


### PR DESCRIPTION
### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

Trying to address Issue #87, specifically that the slido export files seem to be named Polls-per-participant- now and so my latest refresh data didn't have access to some data I expected to have. This change pulls those new files, and renames the old ones to match the new ones.

#### What was your approach?

1. Add the `Polls-per-participant` to the `slido_tags` vector (following the pattern of the other tags)
2. Within the `slido_type` vector, using `gsub` to replace `Polls-per-user` with `Polls-per-participant` 


#### What GitHub issue does your pull request address?

Issue #87 

### Tell potential reviewers what kind of feedback you are soliciting.

@cansavvy is this the fix you were envisioning?