### PR TITLE
GA metrics type = "pages" bug

### DIFF
--- a/R/google-analytics.R
+++ b/R/google-analytics.R
@@ -378,7 +378,7 @@ get_multiple_ga_metrics <- function(account_id = NULL,
                                     start_date = "2015-08-14",
                                     end_date = NULL,
                                     dataformat = "dataframe",
-                                    stats_type = c("metrics", "dimensions", "link_clicks")) {
+                                    stats_type = c("metrics", "dimensions", "link_clicks", "pages")) {
   if (is.null(token)) {
     # Get auth token
     token <- get_token(app_name = "google")
@@ -427,6 +427,7 @@ get_multiple_ga_metrics <- function(account_id = NULL,
     if (a_stats_type == "metrics") per_type <- clean_ga_metrics(per_type, type = "metrics")
     if (a_stats_type == "dimensions") per_type <- clean_ga_dimensions(per_type)
     if (a_stats_type == "link_clicks") per_type <- clean_ga_dimensions(per_type)
+    # TODO: needs to be carried through: if (a_stats_type == "pages") per_type <- clean_ga_dimensions(per_type, type = "pages")
 
     return(per_type)
   })


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

This bug: https://github.com/opencasestudies/ocs-metrics-dashboard/actions/runs/13842245358/job/38735368894

Is because metrics with type "pages" when called from `get_multiple_ga_metrics()` aren't being cleaned. 

#### What was your approach?
So far I highlighted where in the code @kweav needs to make some adds. I haven't tested or ran anything yet though so this is just a mapping out of it. 

You'll want to check that `clean_ga_dimensions(per_type, type = "pages")` works properly. I *think* it does and that the problem is just that `get_multiple_ga_metrics()` wasn't doing this call, but I have not investigated this. 

SECOND part: I don't think we added unit tests for type = "pages" so we should add that too. Can you do that @kweav ?

#### What GitHub issue does your pull request address?
There's no issue. Just PRing and documenting all at once. lol.

### Tell potential reviewers what kind of feedback you are soliciting.
